### PR TITLE
Add postBuild script

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-jupyter labextension install qgrid
+jupyter labextension install @jupyter-widgets/jupyterlab-manager qgrid

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+jupyter labextension install qgrid


### PR DESCRIPTION
Closes https://github.com/quantopian/qgrid-notebooks/issues/1

You can try qgrid in lab on binder: https://mybinder.org/v2/gh/gnestor/qgrid-notebooks/postBuild?urlpath=lab

FYI, this also requires that postBuild be made executable:

```
chmod +x file.command
```