### PR TITLE
Get jupyterlab working again

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - jupyterlab
   - qgrid
   - pandas-datareader>=0.5.0
   - matplotlib>=2.1.1

--- a/postBuild
+++ b/postBuild
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-jupyter labextension install qgrid
+jupyter labextension install @jupyter-widgets/jupyterlab-manager qgrid


### PR DESCRIPTION
There was a version conflict before cause by using an old version of jupyterlab.  Including jupyterlab in the environment.yml fixes this issue.