### PR TITLE
Fix event type in argument to _handle_qgrid_msg_helper

### DIFF
--- a/events.ipynb
+++ b/events.ipynb
@@ -283,7 +283,7 @@
     "            'min': change['new'][0],\n",
     "            'type': \"slider\"\n",
     "        },\n",
-    "        'type': \"filter_changed\"\n",
+    "        'type': \"change_filter\"\n",
     "    })\n",
     "\n",
     "int_range.observe(on_value_change, names='value')\n",


### PR DESCRIPTION
The `_handle_qgrid_msg_helper` method does not recognize the "filter_changed" event type. The correct type should be "change_filter` (see [L1546](https://github.com/quantopian/qgrid/blob/7612e2c6a8162d9fc1a336792d8a007b27aa3808/qgrid/grid.py#L1546)).